### PR TITLE
Fix building library settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,10 +20,7 @@ set(VNOID_SOURCES
     "stepping_controller.cpp"
 	)
 
-add_cnoid_library(vnoid_lib
- ${VNOID_HEADERS}
- ${VNOID_SOURCES}
- )
+choreonoid_add_library(vnoid_lib SHARED ${VNOID_HEADERS} ${VNOID_SOURCES})
 
 target_link_libraries(vnoid_lib CnoidBody)
 


### PR DESCRIPTION
The following two reasons motivate me to open this PR.

1. `SHARED` option is required to build controllers

With the current cmake files, I could not build the sample controller with the error:

```
usr/bin/ld: ../../../../lib/libvnoid_lib.a(robot.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTIN5cnoid18AccelerationSensorE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
make[2]: *** [lib/choreonoid-1.8/simplecontroller/vnoid_sample_controller.so] Error 1
make[1]: *** [ext/vnoid/controller/sample_controller/CMakeFiles/vnoid_sample_controller.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
```

It is an well-known link error due to lack of `SHARED` option.
(Yet it is not unclear that why this error does not occur in your environments...)

2. Use `choreonoid_add_library` instead of  deprecated `add_cnoid_library` (see the following link)

 https://github.com/choreonoid/choreonoid/blob/b855a535caae03692fadce906a0f19f5760dcb2d/cmake/ChoreonoidBasicBuildFunctions.cmake#L102-L108