### PR TITLE
remove .dll for linux

### DIFF
--- a/project/vnoid_sample_project.cnoid
+++ b/project/vnoid_sample_project.cnoid
@@ -110,7 +110,7 @@ items:
               data: 
                 isNoDelayMode: false
                 controllerOptions: ""
-                controller: "vnoid_sample_controller.dll"
+                controller: "vnoid_sample_controller"
                 baseDirectory: "Controller directory"
                 reloading: false
                 exportSymbols: false


### PR DESCRIPTION
Removing suffix '.dll' was necessary in my environment.
Without this PR, the controller was not loaded and the robot did not start walking

This PR may work both windows and linux.
(I'm not so sure about windows)

Tested by https://github.com/ytazz/vnoid/pull/4