### PR TITLE
fix for compiling controller on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,11 @@ set(VNOID_SOURCES
     "stepping_controller.cpp"
 	)
 
+if(UNIX)
+choreonoid_add_library(vnoid_lib STATIC ${VNOID_HEADERS} ${VNOID_SOURCES})
+else()
 choreonoid_add_library(vnoid_lib SHARED ${VNOID_HEADERS} ${VNOID_SOURCES})
+endif()
 
 target_link_libraries(vnoid_lib CnoidBody)
 


### PR DESCRIPTION
This may work for both Windows and Linux.
(Not tested on Windows)

For exporting symbol at Linux,  using https://github.com/choreonoid/choreonoid/blob/master/src/Body/exportdecl.h and adding CNOID_EXPORT (see https://github.com/choreonoid/choreonoid/blob/master/src/Body/Body.h#L28) may be required.