### PR TITLE
Retain VnoidJudgeItem in the log playback archive

### DIFF
--- a/plugin/judge/VnoidJudgeItem.cpp
+++ b/plugin/judge/VnoidJudgeItem.cpp
@@ -295,6 +295,15 @@ void VnoidJudgeItem::finalizeSimulation()
 }
 
 
+bool VnoidJudgeItem::isApplicableToLogPlayback() const
+{
+    // The judgement works during log playback as well by observing the
+    // VnoidJudgeTargetDevice states restored from the log, so this item is
+    // retained in the projects saved as log playback archives.
+    return true;
+}
+
+
 void VnoidJudgeItem::collectSectionBBs(SimulatorItem* simulatorItem)
 {
     for(auto* simBody : simulatorItem->simulationBodies()){

--- a/plugin/judge/VnoidJudgeItem.h
+++ b/plugin/judge/VnoidJudgeItem.h
@@ -62,6 +62,8 @@ public:
     virtual bool initializeSimulation(SimulatorItem* simulatorItem) override;
     virtual void finalizeSimulation() override;
 
+    virtual bool isApplicableToLogPlayback() const override;
+
     virtual SgNode* getScene() override;
 
     void setPowerAverageWindow(double t);


### PR DESCRIPTION
`VnoidJudgeItem` was removed from the projects saved as log playback archives, so the automatic judgement did not work when such an archive was played back. This was a problem because the HVAC challenge requires submitting the results as a log playback archive.

The judgement only observes the `VnoidJudgeTargetDevice` states, which are restored from the log, so it works during log playback as well. This PR overrides `isApplicableToLogPlayback()` to return true so that the item is kept in the archive.

Note that this requires updating Choreonoid itself to the latest commit, which introduces the `isApplicableToLogPlayback` virtual function.
