### PR TITLE
Support the latest development version of Choreonoid

### DIFF
--- a/plugin/judge/VnoidJudgeTargetDevice.cpp
+++ b/plugin/judge/VnoidJudgeTargetDevice.cpp
@@ -62,7 +62,12 @@ void VnoidJudgeTargetDevice::copyStateFrom(const DeviceState& other)
 }
 
 
+#if CNOID_INTERNAL_VERSION >= 8
+DeviceState* VnoidJudgeTargetDevice::cloneState
+(DeviceState* /* existingClone */, std::vector<std::function<void()>>* /* completionFunctions */) const
+#else
 DeviceState* VnoidJudgeTargetDevice::cloneState(DeviceState* /* existingClone */) const
+#endif
 {
     return new VnoidJudgeTargetDevice(*this, true);
 }

--- a/plugin/judge/VnoidJudgeTargetDevice.h
+++ b/plugin/judge/VnoidJudgeTargetDevice.h
@@ -2,6 +2,7 @@
 #define CNOID_VNOID_JUDGE_TARGET_DEVICE_H
 
 #include <cnoid/Device>
+#include <cnoid/Config>
 #include <cstdint>
 
 namespace cnoid {
@@ -60,7 +61,16 @@ public:
     virtual bool copyFrom(const Device* other) override;
     void copyStateFrom(const VnoidJudgeTargetDevice& other);
     virtual void copyStateFrom(const DeviceState& other) override;
+    // The completionFunctions argument was added to cloneState in the
+    // internal version 8 of Choreonoid. This device shares no data between
+    // its clones, so it just ignores the argument.
+#if CNOID_INTERNAL_VERSION >= 8
+    virtual DeviceState* cloneState(
+        DeviceState* existingClone,
+        std::vector<std::function<void()>>* completionFunctions) const override;
+#else
     virtual DeviceState* cloneState(DeviceState* existingClone = nullptr) const override;
+#endif
     virtual void forEachActualType(std::function<bool(const std::type_info& type)> func) override;
     virtual int stateSize() const override;
     virtual const double* readState(const double* buf, int size) override;


### PR DESCRIPTION
`DeviceState::cloneState()` has gained a `completionFunctions` argument in the development version of Choreonoid, which broke the build of `VnoidJudgeTargetDevice`.

The signature is now selected with `CNOID_INTERNAL_VERSION`, so the plugin builds against both the new and the old version. The device shares no data between its clones and simply ignores the argument. Compilation was verified against both versions.
